### PR TITLE
Add 'TabletopUI-Network' and 'TabletopUI-Server' to packages

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -9,7 +9,7 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #packages : [ 'TabletopUI-Core', 'TabletopUI-CommandProcessing', 'TabletopUI-ScreenManagement' ]
+      #packages : [ 'TabletopUI-Core', 'TabletopUI-CommandProcessing', 'TabletopUI-ScreenManagement', 'TabletopUI-Network', 'TabletopUI-Server' ]
     }
   }
 }


### PR DESCRIPTION
This PR adds 'TabletopUI-Network' and 'TabletopUI-Server' to packages. This change allows coveralls to calculate a code coverage on those packages